### PR TITLE
Fix template and csr for 1.23 k8s

### DIFF
--- a/k8s-rbac-controller/csr.tf
+++ b/k8s-rbac-controller/csr.tf
@@ -13,7 +13,6 @@ resource "tls_cert_request" "user_csr" {
     for i in local.users_array : "${i.name}-${i.group}" => i
   }
 
-  key_algorithm   = tls_private_key.user_keypair[each.key].algorithm
   private_key_pem = tls_private_key.user_keypair[each.key].private_key_pem
 
   subject {
@@ -22,7 +21,7 @@ resource "tls_cert_request" "user_csr" {
   }
 }
 
-resource "kubernetes_certificate_signing_request" "user_csr" {
+resource "kubernetes_certificate_signing_request_v1" "user_csr" {
   for_each = tls_cert_request.user_csr
 
   metadata {
@@ -32,6 +31,7 @@ resource "kubernetes_certificate_signing_request" "user_csr" {
   spec {
     usages  = ["client auth"]
     request = each.value.cert_request_pem
+    signer_name = "kubernetes.io/kube-apiserver-client"
   }
   auto_approve = true
 }

--- a/k8s-rbac-controller/data.tf
+++ b/k8s-rbac-controller/data.tf
@@ -1,19 +1,3 @@
-data "template_file" "users_kubeconfig" {
-
-  for_each = kubernetes_certificate_signing_request.user_csr
-  template = file("${path.module}/users-kubeconfig.tpl")
-  vars = {
-    certificate-authority-data = local.certificate_authority_data
-    server                     = var.k8s_api_endpoint
-    k8s_cluster_name           = var.k8s_cluster_name
-    user                       = each.key
-    client-certificate-data    = base64encode(each.value.certificate)
-    client-key-data            = base64encode(lookup(tls_private_key.user_keypair, each.key).private_key_pem)
-  }
-
-  depends_on = [kubernetes_certificate_signing_request.user_csr]
-}
-
 data "kubernetes_secret" "sa" {
   for_each = {
     for k, v in local.sa_array : "${v.name}_${v.namespace}" => v
@@ -25,23 +9,4 @@ data "kubernetes_secret" "sa" {
   }
 
   depends_on = [kubernetes_service_account.service_account]
-}
-
-data "template_file" "sa_kubeconfig" {
-
-  for_each = {
-    for k, v in local.sa_array : "${v.name}_${v.namespace}" => v
-  }
-
-  template = file("${path.module}/sa-kubeconfig.tpl")
-  vars = {
-    certificate-authority-data = local.certificate_authority_data
-    server                     = var.k8s_api_endpoint
-    k8s_cluster_name           = var.k8s_cluster_name
-    sa_name                    = each.value["name"]
-    namespace                  = each.value["namespace"]
-    sa_token                   = lookup(data.kubernetes_secret.sa["${each.value["name"]}_${each.value["namespace"]}"].data, "token")
-  }
-
-  depends_on = [data.kubernetes_secret.sa]
 }

--- a/k8s-rbac-controller/files.tf
+++ b/k8s-rbac-controller/files.tf
@@ -1,15 +1,22 @@
 #==================== Users ==================== #
 resource "local_file" "users_kubeconfigs" {
-  for_each             = data.template_file.users_kubeconfig
+  for_each = kubernetes_certificate_signing_request_v1.user_csr
+  content             =  templatefile("${path.module}/users-kubeconfig.tpl", {
+    certificate-authority-data = local.certificate_authority_data
+    server                     = var.k8s_api_endpoint
+    k8s_cluster_name           = var.k8s_cluster_name
+    user                       = each.key
+    client-certificate-data    = base64encode(each.value.certificate)
+    client-key-data            = base64encode(lookup(tls_private_key.user_keypair, each.key).private_key_pem)
+  })
   file_permission      = "0600"
   directory_permission = "0700"
-  sensitive_content    = each.value.rendered
   filename             = "${var.output_files_path}/users/${each.key}/kubeconfig.yaml"
 }
 
 resource "local_file" "private_key" {
   for_each             = tls_private_key.user_keypair
-  sensitive_content    = each.value.private_key_pem
+  content              = each.value.private_key_pem
   filename             = "${var.output_files_path}/users/${each.key}/tls/private_key"
   file_permission      = "0600"
   directory_permission = "0700"
@@ -17,15 +24,15 @@ resource "local_file" "private_key" {
 
 resource "local_file" "user_csr" {
   for_each             = tls_cert_request.user_csr
-  sensitive_content    = each.value.cert_request_pem
+  content              = each.value.cert_request_pem
   filename             = "${var.output_files_path}/users/${each.key}/tls/csr"
   file_permission      = "0600"
   directory_permission = "0700"
 }
 
 resource "local_file" "user_crt" {
-  for_each             = kubernetes_certificate_signing_request.user_csr
-  sensitive_content    = each.value.certificate
+  for_each             = kubernetes_certificate_signing_request_v1.user_csr
+  content              = each.value.certificate
   filename             = "${var.output_files_path}/users/${each.key}/tls/user_crt"
   file_permission      = "0600"
   directory_permission = "0700"
@@ -33,9 +40,18 @@ resource "local_file" "user_crt" {
 
 #==================== Sa ==================== #
 resource "local_file" "sa_kubeconfigs" {
-  for_each             = data.template_file.sa_kubeconfig
+  for_each = {
+    for k, v in local.sa_array : "${v.name}_${v.namespace}" => v
+  }
+  content             =  templatefile("${path.module}/sa-kubeconfig.tpl", {
+    certificate-authority-data = local.certificate_authority_data
+    server                     = var.k8s_api_endpoint
+    k8s_cluster_name           = var.k8s_cluster_name
+    sa_name                    = each.value["name"]
+    namespace                  = each.value["namespace"]
+    sa_token                   = lookup(data.kubernetes_secret.sa["${each.value["name"]}_${each.value["namespace"]}"].data, "token")
+  })
   file_permission      = "0600"
   directory_permission = "0700"
-  sensitive_content    = each.value.rendered
   filename             = "${var.output_files_path}/sa/${each.key}/kubeconfig.yaml"
 }

--- a/k8s-rbac-controller/main.tf
+++ b/k8s-rbac-controller/main.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     tls      = {}
     local    = {}
-    template = {}
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.7.1"


### PR DESCRIPTION
As part of the proposed changes, there are fixes for the incompatibility of the deprecated template provider with the arm64 platform, the templatefile function was used as an alternative. Also fixed issues with CSR release for k8s v1.22 and later by moving to a newer version resource, where the signer_name parameter was additionally added, as it is now required.